### PR TITLE
Initial version of Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+# Build image
+FROM erlang:23.1-alpine AS build
+
+run mkdir /downloads
+add https://github.com/gleam-lang/gleam/releases/download/v0.12.0/gleam-v0.12.0-linux-amd64.tar.gz /downloads
+workdir /downloads
+run tar zxf ./gleam-v0.12.0-linux-amd64.tar.gz
+run cp gleam /usr/bin/gleam
+run chmod +x /usr/bin/gleam
+
+copy . /src
+workdir /src
+
+run rebar3 release
+
+# Release image
+FROM alpine:3.9 AS app
+
+RUN apk add --no-cache bash openssl ncurses-libs
+
+WORKDIR /app
+
+RUN chown nobody:nobody /app
+
+USER nobody:nobody
+
+COPY --from=build --chown=nobody:nobody /src/_build/default/rel/echo ./
+
+ENV HOME=/app
+
+EXPOSE 3000
+
+CMD ["/app/bin/echo", "foreground"]

--- a/README.md
+++ b/README.md
@@ -11,3 +11,24 @@ More importantly it's also an example web application written in the
 ```sh
 rebar3 shell
 ```
+
+## Docker
+
+Build with:
+
+```sh
+docker build -t gleam-echo:latest .
+```
+
+Run with:
+
+```sh
+docker run -p 3000:3000 gleam-echo:latest
+```
+
+And load `http://localhost:3000` in your browser. You should see an instruction to interact with
+the server by POST-ing to `http://localhost:3000/echo` which you can test with:
+
+```sh
+curl -X POST -d "hello gleam" http://localhost:3000/echo
+```

--- a/rebar.config
+++ b/rebar.config
@@ -19,3 +19,8 @@
     {gleam_otp, "~> 0.1"},
     elli
 ]}.
+
+{relx, [{release, {echo, "0.1.0"},
+         [echo, sasl, gleam_otp, gleam_http, gleam_stdlib, gleam_elli]},
+        {mode, prod}]}.
+


### PR DESCRIPTION
To illustrate how to wrap up the echo server in a Dockerfile for easy deployment if you're used to docker.

The aim is to allow users a clear path for deployment if they're not familiar with rebar release process.

It is based on the Phoenix Dockerfile in the docs:

  https://hexdocs.pm/phoenix/releases.html#containers